### PR TITLE
Fix MapPrinter and its iterator by adding '__cc'

### DIFF
--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -566,7 +566,7 @@ class StdMapPrinter:
         def next(self):
             item = self.rbiter.next()
             item = item.dereference()['__value_']
-            result = ('[%d] %s' % (self.count, str(item['first'])), item['second'])
+            result = ('[%d] %s' % (self.count, str(item['__cc']['first'])), item['__cc']['second'])
             self.count += 1
             return result
         
@@ -595,8 +595,8 @@ class StdMapIteratorPrinter:
         self.val = val
 
     def to_string (self):
-        return '[%s] %s' % (self.val['__i_']['__ptr_']['__value_']['first'],
-                            self.val['__i_']['__ptr_']['__value_']['second'])
+        return '[%s] %s' % (self.val['__i_']['__ptr_']['__value_']['__cc']['first'],
+                            self.val['__i_']['__ptr_']['__value_']['__cc']['second'])
 
 class HashtableIterator:
     def __init__ (self, hashtable):


### PR DESCRIPTION
With types like `map<int, int>` and `vector<map<int, int>>`, printing in gdb on OS X 10.4 gave me errors like these (oddly, `pair<int, int>` worked just fine):

    Python Exception <class 'gdb.error'> There is no member or method named first.: 
    $1 = std::__1::map (count=2)

    $2 = std::__1::vector (length=2, capacity=2) = {
    Python Exception <class 'gdb.error'> There is no member or method named first.: 
      [0] = std::__1::map (count=2),
    Python Exception <class 'gdb.error'> There is no member or method named first.: 
      [1] = std::__1::map (count=2)
    }

Disabling reading `.gdbinit` and inspecting an iterator of the map gave me

    $3 = {__cc = {first = 0, second = 1}, __nc = {first = 0, second = 1}}

and adding `[__cc]` to the related classes fixed the problem. Making such modifications in other classes would be a good idea, but I didn't look into where all this should be done.