### PR TITLE
Support clang4 and gdb7.11

### DIFF
--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -15,8 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import gdb
 import re
+import gdb
 
 # Try to use the new-style pretty-printing if available.
 _use_gdb_pp = True
@@ -110,7 +110,7 @@ class UniquePointerPrinter:
 
     def to_string(self):
         v = self.val['__ptr_']['__first_']
-        return ('%s<%s> = %s => %s' % (str(self.typename), str(v.type.target()), str(v), v.dereference()))
+        return '%s<%s> = %s => %s' % (str(self.typename), str(v.type.target()), str(v), v.dereference())
 
 class StdPairPrinter:
     "Print a std::pair"
@@ -144,9 +144,9 @@ class StdTuplePrinter:
         def __next__(self):
             if self.count >= len(self.fields):
                 raise StopIteration
-            self.field = self.head.cast(self.fields[self.count].type)['value']
+            field = self.head.cast(self.fields[self.count].type)['value']
             self.count += 1
-            return ('[%d]' % (self.count - 1), self.field)
+            return ('[%d]' % (self.count - 1), field)
 
     def __init__(self, typename, val):
         self.typename = typename

--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -68,7 +68,7 @@ class StdStringPrinter:
 
         ss = self.val['__r_']['__first_']['__s']
         __short_mask = 0x1
-        if ((ss['__size_'] & __short_mask) == 0):
+        if (ss['__size_'] & __short_mask) == 0:
             len = (ss['__size_'] >> 1)
             ptr = ss['__data_']
         else:
@@ -76,19 +76,19 @@ class StdStringPrinter:
             len = sl['__size_']
             ptr = sl['__data_']
 
-        return ptr.string(length = len)
+        return ptr.string(length=len)
 
-    def display_hint (self):
+    def display_hint(self):
         return 'string'
 
 class SharedPointerPrinter:
     "Print a shared_ptr or weak_ptr"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
         self.val = val
 
-    def to_string (self):
+    def to_string(self):
         state = 'empty'
         refcounts = self.val['__cntrl_']
         if refcounts != 0:
@@ -104,26 +104,26 @@ class SharedPointerPrinter:
 class UniquePointerPrinter:
     "Print a unique_ptr"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
         self.val = val
 
-    def to_string (self):
+    def to_string(self):
         v = self.val['__ptr_']['__first_']
         return ('%s<%s> = %s => %s' % (str(self.typename), str(v.type.target()), str(v), v.dereference()))
 
 class StdPairPrinter:
     "Print a std::pair"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
-        self.val = val;
+        self.val = val
 
-    def children (self):
+    def children(self):
         return [('first', self.val['first']),
                 ('second', self.val['second'])]
 
-    def to_string (self):
+    def to_string(self):
         return 'pair'
 
 #    def display_hint(self):
@@ -133,12 +133,12 @@ class StdTuplePrinter:
     "Print a std::tuple"
 
     class _iterator:
-        def __init__ (self, head):
+        def __init__(self, head):
             self.head = head['base_']
             self.fields = self.head.type.fields()
             self.count = 0
 
-        def __iter__ (self):
+        def __iter__(self):
             return self
 
         def __next__(self):
@@ -148,15 +148,15 @@ class StdTuplePrinter:
             self.count += 1
             return ('[%d]' % (self.count - 1), self.field)
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
-        self.val = val;
+        self.val = val
 
-    def children (self):
-        return self._iterator (self.val)
+    def children(self):
+        return self._iterator(self.val)
 
-    def to_string (self):
-        if len (self.val.type.fields ()) == 0:
+    def to_string(self):
+        if len(self.val.type.fields()) == 0:
             return 'empty %s' % (self.typename)
         return 'tuple'
 
@@ -249,12 +249,12 @@ class StdVectorPrinter:
     "Print a std::vector"
 
     class _iterator:
-        def __init__ (self, start, finish_or_size, bits_per_word, bitvec):
+        def __init__(self, start, finish_or_size, bits_per_word, bitvec):
             self.bitvec = bitvec
             if bitvec:
-                self.item   = start
-                self.so     = 0
-                self.size   = finish_or_size
+                self.item = start
+                self.so = 0
+                self.size = finish_or_size
                 self.bits_per_word = bits_per_word
             else:
                 self.item = start
@@ -298,24 +298,24 @@ class StdVectorPrinter:
     def children(self):
         if self.is_bool:
             return self._iterator(self.val['__begin_'],
-                              self.val['__size_'],
-                              self.val['__bits_per_word'],
-                              self.is_bool)
+                                  self.val['__size_'],
+                                  self.val['__bits_per_word'],
+                                  self.is_bool)
         else:
             return self._iterator(self.val['__begin_'],
-                              self.val['__end_'],
-                              0,
-                              self.is_bool)
+                                  self.val['__end_'],
+                                  0,
+                                  self.is_bool)
 
     def to_string(self):
         start = self.val['__begin_']
         if self.is_bool:
-            length   = self.val['__size_']
+            length = self.val['__size_']
             capacity = self.val['__cap_alloc_']['__first_'] * self.val['__bits_per_word']
             if length == 0:
                 return 'empty %s<bool> (capacity=%d)' % (self.typename, int(capacity))
             else:
-                return ('%s<bool> (length=%d, capacity=%d)' % (self.typename, int(length), int(capacity)))
+                return '%s<bool> (length=%d, capacity=%d)' % (self.typename, int(length), int(capacity))
         else:
             finish = self.val['__end_']
             end = self.val['__end_cap_']['__first_']
@@ -324,7 +324,7 @@ class StdVectorPrinter:
             if length == 0:
                 return 'empty %s (capacity=%d)' % (self.typename, int(capacity))
             else:
-                return ('%s (length=%d, capacity=%d)' % (self.typename, int(length), int(capacity)))
+                return '%s (length=%d, capacity=%d)' % (self.typename, int(length), int(capacity))
 
 #    def display_hint(self):
 #        return 'array'
@@ -336,7 +336,7 @@ class StdVectorIteratorPrinter:
         self.val = val
 
     def to_string(self):
-        return self.val['__i'].dereference();
+        return self.val['__i'].dereference()
 
 class StdVectorBoolIteratorPrinter:
     "Print std::vector<bool>::iterator"
@@ -376,7 +376,7 @@ class StdDequePrinter:
             old_p = self.p
 
             self.count += 1
-            self.p += 1;
+            self.p += 1
             if (self.p - self.mp.dereference()) == self.block_size:
                 self.mp += 1
                 self.p = self.mp.dereference()
@@ -418,19 +418,19 @@ class StdDequeIteratorPrinter:
 class StdStackOrQueuePrinter:
     "Print a std::stack or std::queue"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
         self.visualizer = gdb.default_visualizer(val['c'])
 
-    def children (self):
+    def children(self):
         return self.visualizer.children()
 
-    def to_string (self):
+    def to_string(self):
         return '%s = %s' % (self.typename, self.visualizer.to_string())
 
-    def display_hint (self):
-        if hasattr (self.visualizer, 'display_hint'):
-            return self.visualizer.display_hint ()
+    def display_hint(self):
+        if hasattr(self.visualizer, 'display_hint'):
+            return self.visualizer.display_hint()
         return None
 
 class StdBitsetPrinter:
@@ -441,10 +441,10 @@ class StdBitsetPrinter:
         self.val = val
         self.bit_count = val.type.template_argument(0)
 
-    def to_string (self):
+    def to_string(self):
         return '%s (length=%d)' % (self.typename, self.bit_count)
 
-    def children (self):
+    def children(self):
         words = self.val['__first_']
         words_count = self.val['__n_words']
         bits_per_word = self.val['__bits_per_word']
@@ -485,19 +485,19 @@ class StdSetPrinter:
             self.count += 1
             return result
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
         self.val = val
         self.rbiter = RbtreeIterator(self.val['__tree_'])
 
-    def to_string (self):
+    def to_string(self):
         length = len(self.rbiter)
         if length == 0:
             return 'empty %s' % self.typename
         else:
             return '%s (count=%d)' % (self.typename, int(length))
 
-    def children (self):
+    def children(self):
         return self._iterator(self.rbiter)
 
 #    def display_hint (self):
@@ -514,7 +514,7 @@ class RbtreeIterator:
         return self
 
     def __len__(self):
-        return int (self.size)
+        return int(self.size)
 
     def __next__(self):
         if self.count == self.size:
@@ -542,10 +542,10 @@ class RbtreeIterator:
 class StdRbtreeIteratorPrinter:
     "Print std::set::iterator"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.val = val
 
-    def to_string (self):
+    def to_string(self):
         return self.val['__ptr_']['__value_']
 
 class StdMapPrinter:
@@ -570,19 +570,19 @@ class StdMapPrinter:
             self.count += 1
             return result
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
         self.val = val
         self.rbiter = RbtreeIterator(val['__tree_'])
 
-    def to_string (self):
+    def to_string(self):
         length = len(self.rbiter)
         if length == 0:
             return 'empty %s' % self.typename
         else:
             return '%s (count=%d)' % (self.typename, int(length))
 
-    def children (self):
+    def children(self):
         return self._iterator(self.rbiter)
 
 #    def display_hint (self):
@@ -591,18 +591,18 @@ class StdMapPrinter:
 class StdMapIteratorPrinter:
     "Print std::map::iterator"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.val = val
 
-    def to_string (self):
+    def to_string(self):
         return '[%s] %s' % (self.val['__i_']['__ptr_']['__value_']['__cc']['first'],
                             self.val['__i_']['__ptr_']['__value_']['__cc']['second'])
 
 class HashtableIterator:
-    def __init__ (self, hashtable):
+    def __init__(self, hashtable):
         self.node = hashtable['__p1_']['__first_']['__next_']
         self.size = hashtable['__p2_']['__first_']
-    def __iter__ (self):
+    def __iter__(self):
         return self
 
     def __len__(self):
@@ -628,26 +628,26 @@ class HashtableIterator:
 class StdHashtableIteratorPrinter:
     "Print std::unordered_set::iterator"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.val = val
 
-    def to_string (self):
+    def to_string(self):
         return self.val['__node_']['__value_']
 
 class StdUnorderedMapIteratorPrinter:
     "Print std::unordered_map::iterator"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.val = val
 
-    def to_string (self):
+    def to_string(self):
         return '[%s] %s' % (self.val['__i_']['__node_']['__value_']['first'],
                             self.val['__i_']['__node_']['__value_']['second'])
 
 class UnorderedSetPrinter:
     "Print a std::unordered_set"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
         self.val = val
         self.hashtable = val['__table_']
@@ -674,7 +674,7 @@ class UnorderedSetPrinter:
 class UnorderedMapPrinter:
     "Print a std::unordered_map"
 
-    def __init__ (self, typename, val):
+    def __init__(self, typename, val):
         self.typename = typename
         self.val = val
         self.hashtable = val['__table_']
@@ -749,10 +749,10 @@ class Printer(object):
     def get_basic_type(type):
         # If it points to a reference, get the reference.
         if type.code == gdb.TYPE_CODE_REF:
-            type = type.target ()
+            type = type.target()
 
         # Get the unqualified type, stripped of typedefs.
-        type = type.unqualified ().strip_typedefs ()
+        type = type.unqualified().strip_typedefs()
 
         return type.tag
 
@@ -826,11 +826,11 @@ def register_type_printers(obj):
         add_one_type_printer(obj, 'basic_iostream', pfx + 'iostream')
         add_one_type_printer(obj, 'basic_stringbuf', pfx + 'stringbuf')
         add_one_type_printer(obj, 'basic_istringstream',
-                                 pfx + 'istringstream')
+                             pfx + 'istringstream')
         add_one_type_printer(obj, 'basic_ostringstream',
-                                 pfx + 'ostringstream')
+                             pfx + 'ostringstream')
         add_one_type_printer(obj, 'basic_stringstream',
-                                 pfx + 'stringstream')
+                             pfx + 'stringstream')
         add_one_type_printer(obj, 'basic_filebuf', pfx + 'filebuf')
         add_one_type_printer(obj, 'basic_ifstream', pfx + 'ifstream')
         add_one_type_printer(obj, 'basic_ofstream', pfx + 'ofstream')
@@ -843,9 +843,9 @@ def register_type_printers(obj):
         add_one_type_printer(obj, 'regex_iterator', pfx + 'cregex_iterator')
         add_one_type_printer(obj, 'regex_iterator', pfx + 'sregex_iterator')
         add_one_type_printer(obj, 'regex_token_iterator',
-                                 pfx + 'cregex_token_iterator')
+                             pfx + 'cregex_token_iterator')
         add_one_type_printer(obj, 'regex_token_iterator',
-                                 pfx + 'sregex_token_iterator')
+                             pfx + 'sregex_token_iterator')
 
     # Note that we can't have a printer for std::wstreampos, because
     # it shares the same underlying type as std::streampos.
@@ -867,7 +867,7 @@ def register_type_printers(obj):
     add_one_type_printer(obj, 'discard_block_engine', 'ranlux48')
     add_one_type_printer(obj, 'shuffle_order_engine', 'knuth_b')
 
-def register_libcxx_printers (obj):
+def register_libcxx_printers(obj):
     "Register libc++ pretty-printers with objfile Obj."
 
     global _use_gdb_pp
@@ -882,7 +882,7 @@ def register_libcxx_printers (obj):
 
     register_type_printers(obj)
 
-def build_libcxx_dictionary ():
+def build_libcxx_dictionary():
     global libcxx_printer
 
     libcxx_printer = Printer("libc++-v1")
@@ -903,7 +903,7 @@ def build_libcxx_dictionary ():
     libcxx_printer.add_container('std::', 'multimap', StdMapPrinter)
     libcxx_printer.add_container('std::', 'multiset', StdSetPrinter)
     libcxx_printer.add_version('std::', 'priority_queue',
-                                  StdStackOrQueuePrinter)
+                               StdStackOrQueuePrinter)
     libcxx_printer.add_version('std::', 'queue', StdStackOrQueuePrinter)
     libcxx_printer.add_version('std::', 'tuple', StdTuplePrinter)
     libcxx_printer.add_version('std::', 'pair', StdPairPrinter)
@@ -955,31 +955,31 @@ def build_libcxx_dictionary ():
     libcxx_printer.add('std::__debug::forward_list', StdForwardListPrinter)
 
     libcxx_printer.add_container('std::', '__list_iterator',
-                                    StdListIteratorPrinter)
+                                 StdListIteratorPrinter)
     libcxx_printer.add_container('std::', '__list_const_iterator',
-                                    StdListIteratorPrinter)
+                                 StdListIteratorPrinter)
     libcxx_printer.add_version('std::', '__tree_iterator',
-                                    StdRbtreeIteratorPrinter)
+                               StdRbtreeIteratorPrinter)
     libcxx_printer.add_version('std::', '__tree_const_iterator',
-                                    StdRbtreeIteratorPrinter)
+                               StdRbtreeIteratorPrinter)
     libcxx_printer.add_version('std::', '__hash_iterator',
-                                    StdHashtableIteratorPrinter)
+                               StdHashtableIteratorPrinter)
     libcxx_printer.add_version('std::', '__hash_const_iterator',
-                                    StdHashtableIteratorPrinter)
+                               StdHashtableIteratorPrinter)
     libcxx_printer.add_version('std::', '__hash_map_iterator',
-                                    StdUnorderedMapIteratorPrinter)
+                               StdUnorderedMapIteratorPrinter)
     libcxx_printer.add_version('std::', '__hash_map_const_iterator',
-                                    StdUnorderedMapIteratorPrinter)
+                               StdUnorderedMapIteratorPrinter)
     libcxx_printer.add_version('std::', '__map_iterator',
-                                    StdMapIteratorPrinter)
+                               StdMapIteratorPrinter)
     libcxx_printer.add_version('std::', '__map_const_iterator',
-                                    StdMapIteratorPrinter)
+                               StdMapIteratorPrinter)
     libcxx_printer.add_container('std::', '__deque_iterator',
-                                    StdDequeIteratorPrinter)
+                                 StdDequeIteratorPrinter)
     libcxx_printer.add_version('std::', '__wrap_iter',
-                                    StdVectorIteratorPrinter)
+                               StdVectorIteratorPrinter)
     libcxx_printer.add_version('std::', '__bit_iterator',
-                                    StdVectorBoolIteratorPrinter)
+                               StdVectorBoolIteratorPrinter)
 
     # Debug (compiled with -D_GLIBCXX_DEBUG) printer
     # registrations.  The Rb_tree debug iterator when unwrapped
@@ -987,10 +987,10 @@ def build_libcxx_dictionary ():
     # have the __norm namespace. Just use the existing printer
     # registration for that.
     libcxx_printer.add('std::__norm::__list_iterator',
-                            StdListIteratorPrinter)
+                       StdListIteratorPrinter)
     libcxx_printer.add('std::__norm::__list_const_iterator',
-                            StdListIteratorPrinter)
+                       StdListIteratorPrinter)
     libcxx_printer.add('std::__norm::__deque_iterator',
-                            StdDequeIteratorPrinter)
+                       StdDequeIteratorPrinter)
 
-build_libcxx_dictionary ()
+build_libcxx_dictionary()


### PR DESCRIPTION
- The newest gdb uses python3, not python2.
- libc++ internals have changed.

The following classes work: std::string, std::tuple, std::pair, std::map, std::set, std::vector, std::unordered_map, std::unordered_set. I haven't tested other classes yet.
