### PR TITLE
Fix std::wstring printing

### DIFF
--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -148,7 +148,7 @@ class StringPrinter:
             len = sl['__size_']
             ptr = sl['__data_']
 
-        return ptr.string(length=len)
+        return ''.join(chr(ptr[i]) for i in range(len))
 
     def display_hint(self):
         return 'string'


### PR DESCRIPTION
Fixes the below error when trying to print a std::wstring:

Python Exception <class 'gdb.error'> Trying to read string with inappropriate
type `std::__1::basic_string<unsigned short,
base::string16_internals::string16_char_traits, std::__1::allocator<unsigned
short> >::value_type [11]'.: