### PR TITLE
Fix std::wstring printing when the string contains unicode characters

### DIFF
--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -148,7 +148,7 @@ class StringPrinter:
             len = sl['__size_']
             ptr = sl['__data_']
 
-        return ''.join(chr(ptr[i]) for i in range(len))
+        return u''.join(unichr(ptr[i]) for i in range(len))
 
     def display_hint(self):
         return 'string'


### PR DESCRIPTION
Fixes this error:

  File "libcxx-pretty-printers/printers.py", line 151, in to_string
    return ''.join(chr(ptr[i]) for i in range(len))
  File "libcxx-pretty-printers/printers.py", line 151, in <genexpr>
    return ''.join(chr(ptr[i]) for i in range(len))
  ValueError: chr() arg not in range(256)