### PR TITLE
fix unicode printing for python 2 and 3

### DIFF
--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -18,6 +18,7 @@
 import re
 import gdb
 import sys
+from builtins import chr
 
 if sys.version_info[0] > 2:
     # Python 3 stuff
@@ -148,7 +149,7 @@ class StringPrinter:
             len = sl['__size_']
             ptr = sl['__data_']
 
-        return u''.join(unichr(ptr[i]) for i in range(len))
+        return u''.join(chr(ptr[i]) for i in range(len))
 
     def display_hint(self):
         return 'string'


### PR DESCRIPTION
I had this error with GDB 8.3
(gdb) p str
$1 = Python Exception <class 'NameError'> name 'unichr' is not defined:

(gdb) py
>import sys
>print(sys.version)
>end
3.6.9 (default, Nov  7 2019, 10:44:02)
[GCC 8.3.0]
(gdb)

This will fix the compatibility issue:
https://python-future.org/compatible_idioms.html#unichr