### PR TITLE
Added possibility to expand content of Unique and Shared pointers

### DIFF
--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -163,6 +163,20 @@ class StringPrinter:
     def display_hint(self):
         return 'string'
 
+class SmartPtrIterator(Iterator):
+    "An iterator for smart pointer types with a single 'child' value"
+
+    def __init__(self, val):
+        self.val = val
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.val is None:
+            raise StopIteration
+        self.val, val = None, self.val
+        return ('get()', val)
 
 class SharedPointerPrinter:
     "Print a shared_ptr or weak_ptr"
@@ -170,6 +184,10 @@ class SharedPointerPrinter:
     def __init__(self, typename, val):
         self.typename = typename
         self.val = val
+
+    def children (self):
+        v = self.val['__ptr_']
+        return SmartPtrIterator(v)
 
     def to_string(self):
         state = 'empty'
@@ -196,6 +214,10 @@ class UniquePointerPrinter:
     def __init__(self, typename, val):
         self.typename = typename
         self.val = val
+
+    def children (self):
+        v = pair_to_tuple(self.val['__ptr_'])[0]
+        return SmartPtrIterator(v)
 
     def to_string(self):
         v = pair_to_tuple(self.val['__ptr_'])[0]


### PR DESCRIPTION
This change adds the possibility to expand the content of Unique and Shared pointers from VSCode integrated debugger.
The only drawback is that the first child of the pointer to be expanded is a node called "get()", which when expanded gives the content of the de-referenced pointer.
Could be improved, but at least it works.

Implementation for `SmartPtrIterator` class is taken from https://github.com/gcc-mirror/gcc/blob/7ee22dc8925d3db9d42a0724f5e1fcc57562306b/libstdc%2B%2B-v3/python/libstdcxx/v6/printers.py