### PR TITLE
fix "Python Exception <class 'ValueError'>: chr() arg not in range(0x110000)"

### DIFF
--- a/src/libcxx/v1/printers.py
+++ b/src/libcxx/v1/printers.py
@@ -158,7 +158,7 @@ class StringPrinter:
                 len = sl['__size_']
                 ptr = sl['__data_']
 
-        return u''.join(chr(ptr[i]) for i in range(len))
+        return ptr.string()
 
     def display_hint(self):
         return 'string'


### PR DESCRIPTION
I tried the pretty printers with GDB 14.2 and got the above error. I don't know Python, but the fix seems to be working.